### PR TITLE
Fix version file syntax errors

### DIFF
--- a/GameData/MemGraph/MemGraph.version
+++ b/GameData/MemGraph/MemGraph.version
@@ -16,7 +16,6 @@
     "MAJOR": 1,
     "MINOR": 12,
     "PATCH": 0
-  }
   },
   "KSP_VERSION_MIN": {
     "MAJOR": 1,

--- a/MemGraph.version
+++ b/MemGraph.version
@@ -16,7 +16,6 @@
     "MAJOR": 1,
     "MINOR": 12,
     "PATCH": 2
-  }
   },
   "KSP_VERSION_MIN": {
     "MAJOR": 1,


### PR DESCRIPTION
Hi @linuxgurugamer,

Both copies of the version file just had a syntax error introduced in the previous commit, which has blocked the latest release from being added to CKAN. Now it's fixed.

As usual, I strongly recommend https://github.com/DasSkelett/AVC-VersionFileValidator to prevent this from happening.